### PR TITLE
Support Python 3.11.2

### DIFF
--- a/src/dotlocalslashbin.py
+++ b/src/dotlocalslashbin.py
@@ -140,7 +140,11 @@ def _download(
                     member.path = member.path.removeprefix(prefix)
                 if member.path in ignore:
                     continue
-                file.extract(member, path=target.parent, filter="tar")
+                try:
+                    file.extract(member, path=target.parent, filter="tar")
+                except TypeError:  # before 3.11.4 e.g. Debian 12
+                    file.extract(member, path=target.parent)
+
     elif action == "command" and command is not None:
         kwargs = dict(target=target, downloaded=downloaded)
         run(split(command.format(**kwargs)), check=True)


### PR DESCRIPTION
So that the script can be used on Debian 12.

> Changed in version 3.11.4: Added the filter parameter.

-- https://docs.python.org/3.11/library/tarfile.html

The implementation was in https://github.com/python/cpython/pull/102953

Before this change, Debian 12 has Python 3.11.2, so this script errors
on a call with `filter=`

After this change the script does not error.
