### PR TITLE
fix: address warning

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -22,7 +22,7 @@ def dev(session: nox.Session) -> None:
     session.run(PYTHON, "-m", "pip", "install", "--editable", ".[test]")
 
 
-@nox.session(python=PRIMARY)
+@nox.session(python=PRIMARY, venv_backend="none")
 def github_output(session: nox.Session) -> None:
     """Display outputs for CI integration."""
     scripts = set(Path("src").glob("*.py")) - set(Path("src").glob("*_test.py"))


### PR DESCRIPTION
Before this change nox output a warning:

    nox > Warning:
    /home/maxwell-k/github.com/maxwell-k/dotlocalslashbin/.venv/bin/python
    is not installed into the virtualenv, it is located at
    /home/maxwell-k/github.com/maxwell-k/dotlocalslashbin/.venv/bin/python.
    This might cause issues! Pass external=True into run() to silence
    this message.

After this change no such warning is issued.
