### PR TITLE
Fix failing MyPy checks

### DIFF
--- a/src/dotlocalslashbin.py
+++ b/src/dotlocalslashbin.py
@@ -175,9 +175,9 @@ def _download(item: Item) -> None:
 def _untar(item: Item) -> None:
     with tarfile.open(item.downloaded, "r") as file:
         for member in file.getmembers():
-            if member.path in item.ignore:
+            if member.name in item.ignore:
                 continue
-            member.path = member.path.removeprefix(item.prefix)
+            member.name = member.name.removeprefix(item.prefix)
             try:
                 file.extract(member, path=item.target.parent, filter="tar")
             except TypeError:  # before 3.11.4 e.g. Debian 12


### PR DESCRIPTION
Before this change mypy fails with the following error:

    src/dotlocalslashbin.py:180: error: Trying to assign name "path" that is not in "__slots__" of type "tarfile.TarInfo"  [misc]

Checking tarfile.py, path is not listed in `__slots__` for TarInfo. However, the docstring for the path method explains:

    'In pax headers, "name" is called "path".'

—<https://github.com/python/cpython/blob/3.13/Lib/tarfile.py#L948>
